### PR TITLE
Simplyfied Api

### DIFF
--- a/Swashbuckle.AspNetCore.Polymorphism/Extensions/SwaggerGeneratorOptionsExtensions.cs
+++ b/Swashbuckle.AspNetCore.Polymorphism/Extensions/SwaggerGeneratorOptionsExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Swashbuckle.AspNetCore.Polymorphism.Extensions
+{
+    public static class SwaggerGeneratorOptionsExtensions
+    {
+        public static void AddTypes(this SwaggerGenOptions self, Type[] typesToRegister)
+        {
+            if(typesToRegister == null) throw new ArgumentNullException(nameof(typesToRegister));
+            if(typesToRegister.Any() == false) throw new ArgumentException("types cannot be empty", nameof(typesToRegister));
+            
+            var parser = new TypesPasser(typesToRegister);
+            self.DocumentFilter<PolymorphismDocumentFilter>(parser);
+            self.SchemaFilter<PolymorphismSchemaFilter>(parser);
+        }
+    }
+}

--- a/Swashbuckle.AspNetCore.Polymorphism/PolymorphismDocumentFilter.cs
+++ b/Swashbuckle.AspNetCore.Polymorphism/PolymorphismDocumentFilter.cs
@@ -6,11 +6,11 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Swashbuckle.AspNetCore.Polymorphism
 {
-    public class PolymorphismDocumentFilter : IDocumentFilter
+    internal class PolymorphismDocumentFilter : IDocumentFilter
     {
         private readonly Type[] _types;
 
-        public PolymorphismDocumentFilter(TypesPasser types)
+        internal PolymorphismDocumentFilter(TypesPasser types)
         {
             _types = types.Types;
         }
@@ -43,7 +43,6 @@ namespace Swashbuckle.AspNetCore.Polymorphism
             {
                 RegisterSubClasses(context.SchemaRegistry, type);
             }
-
         }
     }
 }

--- a/Swashbuckle.AspNetCore.Polymorphism/PolymorphismSchemaFilter.cs
+++ b/Swashbuckle.AspNetCore.Polymorphism/PolymorphismSchemaFilter.cs
@@ -6,7 +6,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Swashbuckle.AspNetCore.Polymorphism
 {
-    public class PolymorphismSchemaFilter : ISchemaFilter
+    internal class PolymorphismSchemaFilter : ISchemaFilter
     {
         private readonly Type[] _types;
 
@@ -24,34 +24,26 @@ namespace Swashbuckle.AspNetCore.Polymorphism
 
             foreach (var type in _types)
             {
-
-
                 var abstractType = type;
                 var dTypes = abstractType.Assembly
                     .GetTypes()
                     .Where(x => abstractType != x && abstractType.IsAssignableFrom(x));
 
-
-
                 foreach (var item in dTypes)
                     result.Add(item);
             }
+            
             return result;
         }
-
 
         public void Apply(Schema model, SchemaFilterContext context)
         {
             if (!_derivedTypes.Value.Contains(context.SystemType)) return;
             ApplyFilter(model, context.SystemType.BaseType);
-
-
         }
 
         private void ApplyFilter(Schema model, Type parent)
         {
-
-
             var clonedSchema = new Schema
             {
                 Properties = model.Properties,

--- a/Swashbuckle.AspNetCore.Polymorphism/Swashbuckle.AspNetCore.Polymorphism.csproj
+++ b/Swashbuckle.AspNetCore.Polymorphism/Swashbuckle.AspNetCore.Polymorphism.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Kenneth Jakobsen</Authors>
@@ -15,9 +14,7 @@
     <RepositoryType>Git</RepositoryType>
     <PackageReleaseNotes>Polymorhism doc and schema filters</PackageReleaseNotes>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.2.0" />
   </ItemGroup>
-
 </Project>

--- a/Swashbuckle.AspNetCore.Polymorphism/TypesPasser.cs
+++ b/Swashbuckle.AspNetCore.Polymorphism/TypesPasser.cs
@@ -2,9 +2,9 @@
 
 namespace Swashbuckle.AspNetCore.Polymorphism
 {
-    public class TypesPasser
+    internal class TypesPasser
     {
-        public TypesPasser(Type[] types)
+        internal TypesPasser(Type[] types)
         {
             Types = types;
         }


### PR DESCRIPTION
- Made extension method to encapsulate registration, this makes it easier to register polymorphic types as well as limiting the api surface area
- In addition i made the PolymorphismDocumentFilter, PolymorphismSchemaFilter and TypesPasser internal, for reasons described in previous bullet